### PR TITLE
added get posts query and endpoint

### DIFF
--- a/backend/post_review/model.py
+++ b/backend/post_review/model.py
@@ -1,0 +1,14 @@
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.ext.declarative import declarative_base
+Base = declarative_base()
+
+class PostReviewModel(Base):
+    __tablename__ = "post"
+
+    id = Column(Integer, primary_key=True, index=True)
+    food_name = Column(String, nullable=False)
+    image = Column(String, nullable=True)
+    restaurant_name = Column(String, nullable=True)
+    rating = Column(String, nullable=False)
+    review = Column(String, nullable=False)
+    tags = Column(String, nullable=True)

--- a/backend/post_review/router.py
+++ b/backend/post_review/router.py
@@ -4,7 +4,7 @@ import schemas as _schemas
 import sqlalchemy.orm as _orm
 from sqlalchemy.orm.session import Session
 from fastapi.security.oauth2 import OAuth2PasswordRequestForm
-import auth.service as _service
+import post_review.service as _service
 from post_review.model import PostReviewModel
 from service_database import get_db
 
@@ -12,3 +12,11 @@ router_post_review = APIRouter(
     prefix="/api/v1/post_review",
     tags=["post_review"]
 )
+
+@router_post_review.get("/get_post_review")
+async def get_post_reviews(db: Session = Depends(get_db)):
+    """ 
+    Get all post reviews from the database.
+    """
+    print('reached')
+    return await _service.get_post_reviews(db)

--- a/backend/post_review/service.py
+++ b/backend/post_review/service.py
@@ -1,0 +1,25 @@
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy import or_, and_, update, delete, insert, select
+import sqlalchemy.orm as _orm
+import post_review.model as _model
+
+MAX_POSTS_TO_FECTH = 20
+
+async def get_post_reviews(db: _orm.Session):
+    """
+    Retrieve all posts from the database.
+
+    :param db: Database session
+    :return: List of all posts
+    """
+    try:
+        posts = db.query(_model.PostReviewModel).all()
+        if not posts:
+            raise HTTPException(status_code=404, detail="No posts found")
+            return None
+        
+        return posts[:MAX_POSTS_TO_FECTH]
+    except:
+        raise HTTPException(status_code=400, detail=f"Posts could not be retrieved")
+        return None

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,8 +17,8 @@ class UserBase(BaseModel):
 # ===============================================================
 class PostReviewBase(BaseModel):
     food_name: str
-    img: str #(optional)
-    rest_name: str #(optional)
+    image: str #(optional)
+    restaurant_name: str #(optional)
     rating: float
     review: str 
     tags: list[str] #(optional)

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -17,8 +17,8 @@ class UserBase(BaseModel):
 # ===============================================================
 class PostReviewBase(BaseModel):
     food_name: str
-    image: str #(optional)
-    restaurant_name: str #(optional)
+    img: str #(optional)
+    rest_name: str #(optional)
     rating: float
     review: str 
     tags: list[str] #(optional)

--- a/backend/tests/testPostModel.py
+++ b/backend/tests/testPostModel.py
@@ -1,0 +1,53 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+from post_review.model import PostReviewModel
+from post_review.service import get_posts
+from backend import database
+import os
+from dotenv import load_dotenv
+
+class testPostModel():
+
+    def setup_class(self):
+        # Load environment variables (if using .env file)
+        load_dotenv()
+
+        DATABASE_URL = f'mysql+mysqlconnector://{os.getenv("DB_USERNAME")}:{os.getenv("DB_PASSWORD")}@{os.getenv("DB_HOST")}/{os.getenv("DB_NAME")}'
+        engine = create_engine(DATABASE_URL)
+        SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+        Base = declarative_base()
+
+        Base.metadata.create_all(engine)
+        self.session = SessionLocal()
+        self.valid_post1 = PostReviewModel(
+            id=1,
+            food_name='burrito',
+            restaurant_name='taco stand',
+            rating=5,
+            review='super good tortilla',
+            tags='mexican food'
+        )
+        self.valid_post2 = PostReviewModel(
+            id=2,
+            food_name='pizza',
+            restaurant_name='Regents Pizza',
+            rating=2,
+            review='funky cheese',
+            tags='pizza'
+        )
+
+    def test_get_post(self):
+        self.session.add(self.valid_post1)
+        self.session.commit()
+        query_result = get_posts(self.session)
+        query_result = query_result[0]
+
+        assert query_result.food_name == 'burrito'
+        assert query_result.restaurant_name == 'taco stand'
+        assert query_result.rating == 5
+        assert query_result.review == 'super good tortilla'
+        assert query_result.tags == 'mexican food'
+
+    def teardown_class(self):
+        self.session.rollback()
+        self.session.close()


### PR DESCRIPTION
# Abstract

This PR includes changes to the backend in order to create an API endpoint for querying post reviews from the SQL database as well the logic for the endpoint. These changes are implemented in the backend/post_review/ folder in the router.py and service.py files. `router.py` handles the endpoint with the function `get_post_reviews` with the endpoint located at `/api/v1/post_review/get_post_review`.  The logic to actually query the SQL database is in `service.py` in the function `get_post_reviews` which queries the database and selects a preset number of posts. Right now the max number of posts to get is set at 20 although it can be changed through the constant `MAX_POSTS_TO_FETCH` in `service.py`.

# Issues

Closes #24 

## Type of Change

- New feature (non-breaking change which adds functionality)

# Testing

Tests for the `service.py` file are located at `backend/tests/testPostModel.py` and include tests to query the database and ensure that the posts that are fetched are correct. In addition to test the endpoint I performed manually testing by ensuring that there was data in the database, running `python main.py` in the `backend` directory to ensure that the backend server was running. I then went to `http://0.0.0.0:6542/api/v1/post_review/get_post_review` in a browser and saw that the returned JSON data matched the data in the SQL database.

# Checklist

- [X ] **The code is understandable.**
- [X ] **The code is well structured.**
- [X ] **The code is correct.**